### PR TITLE
Update build-vbrrepo.sh

### DIFF
--- a/vbrrepo/build-vbrrepo.sh
+++ b/vbrrepo/build-vbrrepo.sh
@@ -74,18 +74,18 @@ while [ -z $zpool ]; do
     printf "${red}ERROR:${nc} Failed to get zpool with name ${yellow}${zpoolname}${nc}, please try again!\n"
   fi
 done
-zpoolfreebytes=$(zpool list -H -p -o free $zpool)
-let zpoolfree=$zpoolfreebytes/1024/1024/1024
-let dssize=$zpoolfree*95/100
+zfsavailbytes=$(zfs list -H -p -o available $zpool)
+let zfsavail=$zfsavailbytes/1024/1024/1024
+let dssize=$zfsavail*95/100
 let zvolsize=$dssize*65/100
 let zvolmaxsize=$dssize*90/100
-printf "\nZPOOL ${yellow}${zpool}${nc} has ${yellow}${zpoolfree}GB${nc} free space.\n"
+printf "\nZFS FileSystem ${yellow}${zpool}${nc} has ${yellow}${zfsavail}GB${nc} available space.\n"
 printf "A dataset named ${yellow}veeam${nc} with ${yellow}${dssize}GB${nc} reserved space in zpool ${yellow}${zpool}${nc} will be created.\n"
 printf "A ZVOL with the name ${yellow}repo_vol${nc} will be created within this dataset.\n"
-printf "This approach leaves some unreserved free space in the parent zpool that can be useful for recovery\n"
+printf "This approach leaves some unreserved free space in the parent zfs filesystem that can be useful for recovery\n"
 printf "in cases where an attacker tries to overwrite all backups and uses all available data/snapshot space.\n"
 printf "in the ${yellow}veeam${nc} dataset\n\n"
-printf "This script calculates recommended values for the ZVOL and snapshot space based on zpool free space.\n"
+printf "This script calculates recommended values for the ZVOL and snapshot space based on zfs filesystem available space.\n"
 printf "It is ${yellow}HIGHLY RECOMMENDED${nc} to use these defaults (ZVOL of 65% of dataset free space).\n"
 printf "However the script will allow the creation of a ZVOL that uses up to 90% of the dataset free space.\n"
 printf "Please be aware that this may not be enough space to store the snapshots and, if the dataset runs\n"
@@ -99,7 +99,7 @@ while [ -z $inputzvolsize ]; do
     fi
 done
 zvolsize=$inputzvolsize
-printf "\nCreating dataset ${yellow}${zpool}/veeam${nc} with quota/reservation of ${yellow}${dssize}GB${nc} on ZPOOL ${yellow}${zpool}${nc}...\n"
+printf "\nCreating dataset ${yellow}${zpool}/veeam${nc} with quota/reservation of ${yellow}${dssize}GB${nc} on ZFS filesystem ${yellow}${zpool}${nc}...\n"
 zfs create ${zpool}/veeam
 zfs set quota=${dssize}GB reservation=${dssize}GB ${zpool}/veeam
 printf "Creating ZVOL ${yellow}repo_vol${nc} of size ${yellow}${zvolsize}GB${nc} on dataset ${yellow}${zpool}/veeam${nc}...\n"


### PR DESCRIPTION
## Description

The issue is that `zpool list -o free` includes parity space and is the wrong value to use as a basis for setting quotas and reservations.  The correct to use is the `zfs list -o available` which excludes parity space.
